### PR TITLE
Enable page caching

### DIFF
--- a/TestSolution/TestSolution/GroupBox/DataTemplateSelectorPage.xaml
+++ b/TestSolution/TestSolution/GroupBox/DataTemplateSelectorPage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:w3c="using:AssyntSoftware.WinUI3Controls"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
 
     <Grid>
         <Grid.Resources>

--- a/TestSolution/TestSolution/GroupBox/PropertiesPage.xaml
+++ b/TestSolution/TestSolution/GroupBox/PropertiesPage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:w3c="using:AssyntSoftware.WinUI3Controls"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
     
     <Grid x:Name="RootPanel">
         <Grid.Resources>
@@ -62,7 +63,10 @@
                             FontSize="{x:Bind fs.Value, Mode=OneWay}">
                         <w3c:GroupBox.Transitions>
                             <TransitionCollection>
-                                <EntranceThemeTransition IsStaggeringEnabled="True" />
+                                <!-- only to prove it works -->
+                                <EntranceThemeTransition 
+                                    FromHorizontalOffset="200" 
+                                    FromVerticalOffset="200"/>
                             </TransitionCollection>
                         </w3c:GroupBox.Transitions>
                         <Grid>

--- a/TestSolution/TestSolution/GroupBox/PropertiesPage.xaml.cs
+++ b/TestSolution/TestSolution/GroupBox/PropertiesPage.xaml.cs
@@ -27,12 +27,21 @@ namespace TestSolution.GroupBox
     /// </summary>
     public sealed partial class PropertiesPage : Page
     {
+        private bool firstLoad = true;
+
         public PropertiesPage()
         {
             this.InitializeComponent();
-            RootPanel.Loaded += (s, e) => InitialiseControls();
-        }
 
+            RootPanel.Loaded += (s, e) =>
+            {
+                if (firstLoad)
+                {
+                    firstLoad = false;
+                    InitialiseControls();
+                }
+            };
+        }
 
 
         private const double cBorderStartPadding = 4;

--- a/TestSolution/TestSolution/GroupBox/StylePage.xaml
+++ b/TestSolution/TestSolution/GroupBox/StylePage.xaml
@@ -7,7 +7,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:w3c="using:AssyntSoftware.WinUI3Controls"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
 
     <Grid>
         <Grid.Resources>

--- a/TestSolution/TestSolution/MainWindow.xaml
+++ b/TestSolution/TestSolution/MainWindow.xaml
@@ -21,7 +21,7 @@
             <NavigationViewItem Content="DataTemplateSelector" Tag="GroupBox.DataTemplateSelectorPage" AccessKey="D" KeyTipPlacementMode="Bottom"/>
         </NavigationView.MenuItems>
 
-        <Frame x:Name="ContentFrame"/>
+        <Frame x:Name="ContentFrame" CacheSize="{x:Bind RootNavigationView.MenuItems.Count}"/>
     </NavigationView>
 
 </Window>


### PR DESCRIPTION
To test if the group box size changed handlers are added/removed correctly when it is loaded/unloaded.