### PR TITLE
Add size changed handlers once

### DIFF
--- a/WinUI3Controls/GroupBox/GroupBox.cs
+++ b/WinUI3Controls/GroupBox/GroupBox.cs
@@ -40,21 +40,16 @@ namespace AssyntSoftware.WinUI3Controls
             RegisterPropertyChangedCallback(CornerRadiusProperty, (s, d) => ((GroupBox)s).BorderPropertyChanged());
             RegisterPropertyChangedCallback(BorderThicknessProperty, (s, d) => ((GroupBox)s).BorderPropertyChanged());
 
+            HeadingPresenter.SizeChanged += (s, e) =>
+            {
+                if (IsLoaded)
+                    BorderPropertyChanged();
+            };
+
+            SizeChanged += (s, e) => ((GroupBox)s).RedrawBorder();
+            
             // initialise
             BorderPropertyChanged();
-
-            Loaded += (s, e) =>
-            {
-                GroupBox gb = (GroupBox)s;
-
-                if (gb.HeadingPresenter is not null)
-                {
-                    gb.HeadingPresenter.SizeChanged += (s, e) => gb.BorderPropertyChanged();
-                    gb.SizeChanged += (s, e) => ((GroupBox)s).RedrawBorder();
-
-                    gb.RedrawBorder(); // first draw
-                }
-            };
         }
 
         private void RedrawBorder()


### PR DESCRIPTION
If the control is reused, i.e. when navigation view pages are cached, new size changed event handlers were added each time the control was loaded. That could result in multiple size change handler invocations. Instead of adding the event handlers on load, add once in OnApplyTemplate() and check IsLoaded in the handler.