### PR TITLE
Don't resize in loaded event

### DIFF
--- a/WinUI3Controls/GroupBox/GroupBox.cs
+++ b/WinUI3Controls/GroupBox/GroupBox.cs
@@ -37,16 +37,14 @@ namespace AssyntSoftware.WinUI3Controls
             RegisterPropertyChangedCallback(CornerRadiusProperty, (s, d) => ((GroupBox)s).BorderPropertyChanged());
             RegisterPropertyChangedCallback(BorderThicknessProperty, (s, d) => ((GroupBox)s).BorderPropertyChanged());
 
-            HeadingPresenter.SizeChanged += (s, e) =>
-            {
-                if (IsLoaded)
-                    BorderPropertyChanged();
-            };
+            HeadingPresenter.SizeChanged += (s, e) => BorderPropertyChanged();
 
             SizeChanged += (s, e) => ((GroupBox)s).RedrawBorder();
 
+            Loaded += (s, e) => ((GroupBox)s).RedrawBorder();
+
             // initialise
-            Loaded += (s, e) => BorderPropertyChanged();
+            BorderPropertyChanged();
         }
 
         private void RedrawBorder()


### PR DESCRIPTION
At the loaded stage layout should be complete and dimensions stable. Setting the content presenter padding at load time caused a size change.