### PR TITLE
Fix build break when consumer targets WAS 1.8.0 preview

### DIFF
--- a/WinUI3Controls/README.md
+++ b/WinUI3Controls/README.md
@@ -7,7 +7,6 @@ It contains two controls, a WinUI implementation of the **WPF GroupBox** control
 The library supports trimming which requires at least:
 
 - Net 6.0
-- Windows App Sdk 1.6.0
-- CsWinRt 2.2.0
+- Windows App Sdk 1.7.0
 
 For more information, including code samples see the home [repository](https://github.com/DHancock/WinUI3Controls/tree/main).

--- a/WinUI3Controls/WinUI3Controls.csproj
+++ b/WinUI3Controls/WinUI3Controls.csproj
@@ -17,9 +17,10 @@ Built for use with the Windows App SDK.</Description>
     <RepositoryUrl>https://github.com/DHancock/WinUI3Controls</RepositoryUrl>
     <Authors>David Hancock</Authors>
     <PackageProjectUrl>https://github.com/DHancock/WinUI3Controls</PackageProjectUrl>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
 	<IsTrimmable>True</IsTrimmable>
 	<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+	<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -38,8 +39,7 @@ Built for use with the Windows App SDK.</Description>
 	
   <ItemGroup>
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When the library was built using Win App Sdk 1.6 extra entries were added to the library's pri file in error. They are for the webview2 loader, one for each native platform. This didn't cause any issues until the nuget was added to a project targeting Win App Sdk 1.8 preview. That caused the build to attempt to copy the loader to the output, but as they didn't exist the build was broken.